### PR TITLE
Change to Captcha::reCAPTCHA::V2

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,7 +12,7 @@ copyright_year   = 2014
 [VersionFromModule]
 
 [Prereqs]
-Captcha::reCAPTCHA = 0
+Captcha::reCAPTCHA::V2 = 0
 Dancer = 1.3110
 
 [Prereqs / TestRequires]

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -2,7 +2,7 @@
  
 use Test::More;
  
-BEGIN { use_ok( 'Captcha::reCAPTCHA' ); }
+BEGIN { use_ok( 'Captcha::reCAPTCHA::V2' ); }
 BEGIN { use_ok( 'Dancer::Plugin::reCAPTCHA' ); }
  
 done_testing;


### PR DESCRIPTION
Update to use the Captcha::reCAPTCHA::V2 module for displaying and
verifying the reCAPTCHA.

There are changes to the interface and configuration required from the
previous reCAPTCHA module. The updates have been made to the
documentation and code as required.